### PR TITLE
Make compatible with Dart 3.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/roscale/arena_listener
 issue_tracker: https://github.com/roscale/arena_listener/issues
 
 environment:
-  sdk: '>=3.0.6 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
Gets rid of this issue if Flutter 3.10.5 is used:
```
The current Dart SDK version is 3.0.5.

Because [name] depends on arena_listener any which requires SDK version >=3.0.6 <4.0.0, version solving failed.
```